### PR TITLE
fix: update to @dabh/colors for security vuln

### DIFF
--- a/packages/generic-icon-splash-generate/package.json
+++ b/packages/generic-icon-splash-generate/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/randytarampi/generic-icon-splash-generate/issues",
   "dependencies": {
-    "colors": "^1.4.0",
+    "@dabh/colors": "^1.4.0",
     "mkdirp": "^1.0.4",
     "sharp": "^0.28.0",
     "snyk": "^1.430.0"


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR updates the color package to using [@dabh/colors](https://www.npmjs.com/package/@dabh/colors) as stated on this [colors issue #317](https://github.com/Marak/colors.js/issues/317#issue-1098535594) which is a safe alternative.

cc: @randytarampi